### PR TITLE
fix Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 const axios = require("axios");
+const fs = require("node:fs");
+const path = require("node:path");
 const tar = require("tar");
-const fs = require("fs");
-const path = require("path");
+const unzipper = require("unzipper");
 const pkg = require("./package.json");
-const { spawn } = require("child_process");
-
-const args = process.argv.slice(2);
 
 const isWindows = process.platform === "win32";
 const outputPath = path.join(__dirname, "bin");
@@ -44,7 +42,7 @@ async function downloadAndExtract() {
   return new Promise((resolve, reject) => {
     let pipe;
     if (isWindows) {
-      pipe = response.pipe(unzipper.Extract({ path: outputPath }));
+      pipe = response.data.pipe(unzipper.Extract({ path: outputPath }));
     } else {
       pipe = response.data.pipe(tar.extract({ cwd: outputPath }));
     }


### PR DESCRIPTION
# Why

Spotted out lately that our prose linting command does not work on Windows, while on macOS everything seems to be fine, so decided to debug it.

![Screenshot 2024-12-30 124913](https://github.com/user-attachments/assets/588c5202-b485-4211-9024-96efd19931a8)

# How

During the investigation I have found two following issues:
* the pipe in Windows branch was executed on the whole response instead of `data`, which lead to throw on calling undefined `pipe` function
* `unzipper` was used in Windows code branch, it was specified in `package.json` but its import was not present in the file, which lead to throw on not defined value

In the process I have also removed unused `spawn` import and `args` capture.

# Test plan

Copied over updated `index.js` into `node_modules` of the problematic project, to make sure that lint task ix executed properly after the changes.

![Screenshot 2024-12-30 124947](https://github.com/user-attachments/assets/843c8e91-49a2-4bbb-87ce-f6c39e260453)
